### PR TITLE
Character Categories and Collation-aware Sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,30 @@ U+116E	ᅮ	HANGUL JUNGSEONG U
 U+000A	"\n"	<control>
 ```
 
+Sort input with different collation (`-l`):
+
+```
+❯ cat input.txt
+Œthelwald
+Zeus
+Achilles
+
+❯ cat input.txt | uni sort -l en-US
+Achilles
+Œthelwald
+Zeus
+
+❯ cat input.txt | uni sort -l da
+Achilles
+Zeus
+Œthelwald
+
+❯ cat input.txt | uni sort -l da -r
+Œthelwald
+Zeus
+Achilles
+```
+
 
 `yfmt`
 ------

--- a/README.md
+++ b/README.md
@@ -178,8 +178,51 @@ List characters:
 
 ```
 ❯ uni list java cecak
-U+A981 	ꦁ	JAVANESE SIGN CECAK
-U+A9B3 	꦳	JAVANESE SIGN CECAK TELU
+U+A981 	ꦁ	[EA A6 81   ]	<M,Mn>	JAVANESE SIGN CECAK
+U+A9B3 	꦳	[EA A6 B3   ]	<M,Mn>	JAVANESE SIGN CECAK TELU
+```
+
+List characters with fewer details:
+
+```
+❯ uni list java cecak -o hexbytes,name
+[EA A6 81   ]	JAVANESE SIGN CECAK
+[EA A6 B3   ]	JAVANESE SIGN CECAK TELU
+```
+
+Show only the aggregate count (`-c`), skipping output (`-o none`):
+
+```
+❯ uni list java cecak -o none -c
+Matched 2 runes
+```
+
+Show only characters in a specific character category, e.g.:
+
+```
+# All "Pd" (punctuation, dash)
+❯ uni list -C Pd
+
+# All "S" (symbols)
+❯ uni list -C S
+
+# All "N" (numbers) that aren't "No" (other)
+❯ uni list -C N,!No
+
+# All "Lu" (letters, uppercase) and "Ll" (letters, lowercase)
+❯ uni list -C Lu,Ll
+```
+
+List all character categories, their names, and counts:
+
+```
+❯ uni cats
+KEY   NAME                    RUNE COUNT
+C     Other                   139751
+Cc    Control                 65
+Cf    Format                  170
+Co    Private Use             137468
+[...]
 ```
 
 Describe characters:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: 'golang:1.20-bookworm'
+  - name: 'golang:1.21-bookworm'
     args:
       - bash
       - -c

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tf
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=

--- a/pkg/uni/categories.go
+++ b/pkg/uni/categories.go
@@ -1,0 +1,105 @@
+package uni
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"unicode"
+
+	"github.com/liggitt/tabwriter"
+	"github.com/spf13/cobra"
+	"golang.org/x/text/unicode/rangetable"
+)
+
+var Categories = map[string]string{
+	"C":  "Other",
+	"Cc": "Control",
+	"Cf": "Format",
+	"Co": "Private Use",
+	"Cs": "Surrrogate",
+	"L":  "Letter",
+	"Ll": "Lowercase Letter",
+	"Lm": "Modifier Letter",
+	"Lo": "Other Letter",
+	"Lt": "Titlecase Letter",
+	"Lu": "Uppercase Letter",
+	"M":  "Mark",
+	"Mc": "Spacing Mark",
+	"Me": "Enclosing Mark",
+	"Mn": "Nonspacing Mark",
+	"N":  "Number",
+	"Nd": "Decimal Number",
+	"Nl": "Letter Number",
+	"No": "Other Number",
+	"P":  "Punctuation",
+	"Pc": "Connector Punctuation",
+	"Pd": "Dash Punctuation",
+	"Pe": "Close Punctuation",
+	"Pf": "Final Punctuation",
+	"Pi": "Initial Punctuation",
+	"Po": "Other Punctuation",
+	"Ps": "Open Punctuation",
+	"S":  "Symbol",
+	"Sc": "Currency Symbol",
+	"Sk": "Modifier Symbol",
+	"Sm": "Math Symbol",
+	"So": "Other Symbol",
+	"Z":  "Separator",
+	"Zl": "Line Separator",
+	"Zp": "Paragraph Separator",
+	"Zs": "Space Separator",
+}
+
+func init() {
+	for cat := range unicode.Categories {
+		if _, ok := Categories[cat]; !ok {
+			Categories[cat] = cat
+		}
+	}
+}
+
+func newCategoriesCommand() *cobra.Command {
+	r := &catter{}
+	c := cobra.Command{
+		Use:                   "categories",
+		Aliases:               []string{"cat", "cats"},
+		DisableFlagsInUseLine: true,
+		SilenceErrors:         true,
+
+		Short: "List Unicode categories",
+		RunE:  r.run,
+	}
+
+	c.Flags().StringVarP(&r.table, "table", "t", r.table, "Unicode Table version")
+	return &c
+}
+
+type catter struct {
+	table string
+}
+
+func (_ *catter) run(c *cobra.Command, args []string) error {
+	cats := []string{}
+	for cat := range Categories {
+		cats = append(cats, cat)
+	}
+	sort.Strings(cats)
+
+	t := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', tabwriter.RememberWidths)
+	defer t.Flush()
+
+	fmt.Fprintf(t, "%s\t%s\t%s\n", "KEY", "NAME", "RUNE COUNT")
+	for _, cat := range cats {
+		fmt.Fprintf(t, "%s\t%s\t%d\n", cat, Categories[cat], countCharactersIn(cat))
+	}
+
+	return nil
+}
+
+func countCharactersIn(cat string) int {
+	count := 0
+	rangetable.Visit(unicode.Categories[cat], func(_ rune) {
+		count += 1
+	})
+	return count
+}

--- a/pkg/uni/sort.go
+++ b/pkg/uni/sort.go
@@ -1,0 +1,72 @@
+package uni
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
+)
+
+func newSortCommand() *cobra.Command {
+	s := &sorter{
+		langStr: "en-US",
+	}
+
+	c := cobra.Command{
+		Use:                   "sort",
+		DisableFlagsInUseLine: true,
+		SilenceErrors:         true,
+
+		Short: "Sort",
+		Args:  s.validate,
+		RunE:  s.run,
+	}
+
+	c.Flags().StringVarP(&s.langStr, "language", "l", s.langStr, "Collation language tag")
+	c.Flags().BoolVarP(&s.reverse, "reverse", "r", s.reverse, "Reverse sort order")
+	return &c
+}
+
+type sorter struct {
+	langStr string
+	langTag language.Tag
+	reverse bool
+}
+
+func (s *sorter) validate(_ *cobra.Command, _ []string) error {
+	tag, err := language.Parse(s.langStr)
+	if err != nil {
+		return fmt.Errorf("invalid language tag %q: %w", s.langStr, err)
+	}
+
+	if tag.String() != s.langStr {
+		fmt.Fprintf(os.Stderr, "Warning: interpreted collation %q as %q\n", s.langStr, tag.String())
+	}
+
+	s.langTag = tag
+	return nil
+}
+
+func (s *sorter) run(_ *cobra.Command, _ []string) error {
+	sc := bufio.NewScanner(os.Stdin)
+	lines := []string{}
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+
+	coll := collate.New(s.langTag)
+	coll.SortStrings(lines)
+	if s.reverse {
+		slices.Reverse(lines)
+	}
+
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+
+	return nil
+}

--- a/pkg/uni/sort.go
+++ b/pkg/uni/sort.go
@@ -28,7 +28,24 @@ func newSortCommand() *cobra.Command {
 
 	c.Flags().StringVarP(&s.langStr, "language", "l", s.langStr, "Collation language tag")
 	c.Flags().BoolVarP(&s.reverse, "reverse", "r", s.reverse, "Reverse sort order")
+
+	cl := cobra.Command{
+		Use:                   "list",
+		DisableFlagsInUseLine: true,
+		SilenceErrors:         true,
+
+		RunE: doCollationList,
+	}
+	c.AddCommand(&cl)
+
 	return &c
+}
+
+func doCollationList(_ *cobra.Command, _ []string) error {
+	for _, tag := range collate.Supported() {
+		fmt.Printf("%s\n", tag.String())
+	}
+	return nil
 }
 
 type sorter struct {

--- a/pkg/uni/uni.go
+++ b/pkg/uni/uni.go
@@ -9,6 +9,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
+	c.AddCommand(newCategoriesCommand())
 	c.AddCommand(newDescribeCommand())
 	c.AddCommand(newListCommand())
 	c.AddCommand(newMapCommand())

--- a/pkg/uni/uni.go
+++ b/pkg/uni/uni.go
@@ -15,5 +15,6 @@ func NewCommand() *cobra.Command {
 	c.AddCommand(newMapCommand())
 	c.AddCommand(newNFCCommand())
 	c.AddCommand(newNFDCommand())
+	c.AddCommand(newSortCommand())
 	return &c
 }


### PR DESCRIPTION
1. New `uni sort` that sorts input. The flag `-l`sorts using a language-specific collation. Collations are from [golang.org/x/text/collate](https://pkg.go.dev/golang.org/x/text/collate) and compiled in.
2. New `uni sort list` that lists all the language-specific collations compiled in.
3. Expanded `uni list` with new default option `-o categories` that shows the [character category](https://en.wikipedia.org/wiki/Template:General_Category_(Unicode)).
4. Expanded `uni list` with new `--categories` (`-C`) to select list by character category.
5. Add `uni cat` that shows an aggregate report of unicode character categories.